### PR TITLE
Fix #7 filter/filter, flat/flat with zip

### DIFF
--- a/src/main/scala/lms/ScalaCompileMultiParams.scala
+++ b/src/main/scala/lms/ScalaCompileMultiParams.scala
@@ -21,7 +21,7 @@ trait ScalaCompileMultiParams extends ScalaCompile {
     if (this.compiler eq null)
       setupCompiler()
 
-     println(source)
+    if(dumpGeneratedCode) println(source)
 
     val compiler = this.compiler
     val run = new compiler.Run

--- a/src/main/scala/microbenchmarks/S.scala
+++ b/src/main/scala/microbenchmarks/S.scala
@@ -2,15 +2,7 @@ package microbenchmarks
 
 import streams._
 import lms._
-
-import org.openjdk.jmh.annotations.Benchmark
-import org.openjdk.jmh.annotations.Scope
-import org.openjdk.jmh.annotations.Setup
-import org.openjdk.jmh.annotations.State
-import org.openjdk.jmh.annotations.BenchmarkMode
-import org.openjdk.jmh.annotations.Mode
-import org.openjdk.jmh.annotations.Fork
-import org.openjdk.jmh.annotations.OutputTimeUnit
+import org.openjdk.jmh.annotations._
 import java.util.concurrent.TimeUnit
 
 import scala.lms.common._

--- a/src/main/scala/microbenchmarks/S.scala
+++ b/src/main/scala/microbenchmarks/S.scala
@@ -93,7 +93,7 @@ trait StagedStreamBenchmarksS extends StagedStream {
       .fold(unit(0), ((a : Rep[Int])=> (b : Rep[Int]) => a + b))
   def zip_filter_filter (xs : Rep[Array[Int]], ys: Rep[Array[Int]]) : Rep[Int] =
      Stream[Int](xs)
-      .filter(_ > 5)
+      .filter(_ < 3)
       .zip(((a : Rep[Int]) => (b : Rep[Int]) => a + b), 
         Stream[Int](ys).filter(_ > 5))
       .fold(unit(0), ((a : Rep[Int])=> (b : Rep[Int]) => a + b))

--- a/src/test/scala/StagedStreamSpec.scala
+++ b/src/test/scala/StagedStreamSpec.scala
@@ -66,7 +66,7 @@ trait StagedStreamTests extends StagedStream {
   def zip_filter_filter (xs : Rep[Array[Int]], ys: Rep[Array[Int]], num: Rep[Int]) : Rep[Int] =
     Stream[Int](xs)
       .filter(_ < num)
-      .zip(((a : Rep[Int]) => (b : Rep[Int]) => a + b), 
+      .zip(((a : Rep[Int]) => (b : Rep[Int]) => a + b),
         Stream[Int](ys).filter(_ > num))
       .fold(unit(0), ((a : Rep[Int])=> (b : Rep[Int]) => a + b))
 }
@@ -191,7 +191,7 @@ object StagedStreamSpec extends Properties("Staged Stream") {
   }
 
   property("zip/flat/flat") = forAll { (xs: Array[Int], ys: Array[Int], num: Int) =>
-    var x = (xs.flatMap((x : Int) => ys.map(y => x + y)), ys.flatMap((x : Int) => xs.map(y => x + y))).zipped.map(_ + _).take(num).sum
+    var x = (xs.flatMap((x : Int) => ys.map(y => x * y)), ys.flatMap((x : Int) => xs.map(y => x * y))).zipped.map(_ + _).take(num).sum
     val y = staged.zip_flat_flat_take(xs, ys, num)
     x == y
   }

--- a/src/test/scala/StagedStreamSpec.scala
+++ b/src/test/scala/StagedStreamSpec.scala
@@ -55,19 +55,19 @@ trait StagedStreamTests extends StagedStream {
       Stream(Linear(Stream[Int](xs).makeLinear(stream)))
       .fold(0, ((a : Rep[Int])=> (b : Rep[Int]) => a + b))
   }
-  def zip_flat_flat_take (vHi : Rep[Array[Int]], vLo : Rep[Array[Int]]) : Rep[Int] =
+  def zip_flat_flat_take (vHi : Rep[Array[Int]], vLo : Rep[Array[Int]], num: Rep[Int]) : Rep[Int] =
     Stream[Int](vHi)
       .flatmap(x => Stream[Int](vLo).map(y => (x * y)))
       .zip(x => (y:Rep[Int]) => x + y,
         Stream[Int](vLo)
           .flatmap(x => Stream[Int](vHi).map(y => (x * y))))
-      .take(20000000)
+      .take(num)
       .fold(unit(0), ((a : Rep[Int])=> (b : Rep[Int]) => a + b))
-  def zip_filter_filter (xs : Rep[Array[Int]], ys: Rep[Array[Int]]) : Rep[Int] =
+  def zip_filter_filter (xs : Rep[Array[Int]], ys: Rep[Array[Int]], num: Rep[Int]) : Rep[Int] =
     Stream[Int](xs)
-      .filter(_ > 5)
-      .zip(((a : Rep[Int]) => (b : Rep[Int]) => a + b),
-        Stream[Int](ys).filter(_ > 5))
+      .filter(_ < num)
+      .zip(((a : Rep[Int]) => (b : Rep[Int]) => a + b), 
+        Stream[Int](ys).filter(_ > num))
       .fold(unit(0), ((a : Rep[Int])=> (b : Rep[Int]) => a + b))
 }
 
@@ -120,8 +120,8 @@ object StagedStreamSpec extends Properties("Staged Stream") {
     val zip_with_simpleTest : ((Array[Int], Array[Int]) => Int) = compile2(self.zip_with_simpleTest)
     val zip_with_genTest : ((Array[Int], Array[Int]) => Int) = compile2(self.zip_with_genTest)
     val makeLinearTest : (Array[Int] => Int) = compile(self.makeLinearTest)
-    val zip_flat_flat_take : ((Array[Int], Array[Int]) => Int) = compile2(self.zip_flat_flat_take)
-    val zip_filter_filter : ((Array[Int], Array[Int]) => Int) = compile2(self.zip_filter_filter)
+    val zip_flat_flat_take : ((Array[Int], Array[Int], Int) => Int) = compile3(self.zip_flat_flat_take)
+    val zip_filter_filter : ((Array[Int], Array[Int], Int) => Int) = compile3(self.zip_filter_filter)
   }
 
   property("size") = forAll { (xs: Array[Int]) =>
@@ -190,15 +190,15 @@ object StagedStreamSpec extends Properties("Staged Stream") {
     x == y
   }
 
-  property("zip/flat/flat") = forAll { (xs: Array[Int], ys: Array[Int]) =>
-    var x = (xs.flatMap((x : Int) => ys.map(y => x * y)), ys.flatMap((x : Int) => xs.map(y => x * y))).zipped.map(_ + _).take(20000000).sum
-    val y = staged.zip_flat_flat_take(xs, ys)
+  property("zip/flat/flat") = forAll { (xs: Array[Int], ys: Array[Int], num: Int) =>
+    var x = (xs.flatMap((x : Int) => ys.map(y => x + y)), ys.flatMap((x : Int) => xs.map(y => x + y))).zipped.map(_ + _).take(num).sum
+    val y = staged.zip_flat_flat_take(xs, ys, num)
     x == y
   }
 
-  property("zip/filter/filter") = forAll { (xs: Array[Int], ys: Array[Int]) =>
-    var x = (xs.filter(_ > 5), ys.filter(_ > 5)).zipped.map(_ + _).sum
-    val y = staged.zip_filter_filter(xs, ys)
+  property("zip/filter/filter") = forAll { (xs: Array[Int], ys: Array[Int], num: Int) =>
+    var x = (xs.filter(_ < num), ys.filter(_ > num)).zipped.map(_ + _).sum
+    val y = staged.zip_filter_filter(xs, ys, num)
     x == y
   }
 }


### PR DESCRIPTION
Reopening #7

```shell
> sbt test
[info] + Staged Stream.zip/filter/filter: OK, passed 100 tests.
[info] + Staged Stream.sum: OK, passed 100 tests.
[info] + Staged Stream.filter: OK, passed 100 tests.
[info] + Staged Stream.zip simple/sum: OK, passed 100 tests.
[info] + Staged Stream.flatmap: OK, passed 100 tests.
[info] + Staged Stream.take/size: OK, passed 100 tests.
[info] + Staged Stream.zip gen/sum: OK, passed 100 tests.
[info] + Staged Stream.size: OK, passed 100 tests.
[info] + Staged Stream.makeLinearTest: OK, passed 100 tests.
[info] + Staged Stream.flatmap/take/size: OK, passed 100 tests.
[info] + Staged Stream.filter/filter: OK, passed 100 tests.
[info] + Staged Stream.map/fold: OK, passed 100 tests.
[info] ! Staged Stream.zip/flat/flat: Falsified after 20 passed tests.
[info] > ARG_0: [I@5cce9cdb
[info] > ARG_0_ORIGINAL: [I@5db585e2
[info] > ARG_1: [I@14c42ace
[info] > ARG_1_ORIGINAL: [I@1d4e238a
[info] > ARG_2: 2147483647
[info] ScalaCheck
[info] Failed: Total 13, Failed 1, Errors 0, Passed 12
[info] ScalaTest
```

and

```
> jmh:run -i 2 -wi 2 -f1 .*filter_filter.*
[info] <stdin>:13: error: type mismatch;
[info]  found   : () => Unit
[info]  required: Unit => Unit
[info] var x350: scala.Function1[Unit,Unit] = x349
[info]                                        ^
[info] <stdin>:47: error: type mismatch;
[info]  found   : () => Unit
[info]  required: Unit => Unit
[info] x350 = x378
[info]        ^
[info] <stdin>:73: error: type mismatch;
[info]  found   : () => Unit
[info]  required: Unit => Unit
[info] x350 = x399
[info]        ^
[info] <stdin>:104: error: type mismatch;
[info]  found   : () => Unit
[info]  required: Unit => Unit
[info] x350 = x425
[info]        ^
[info] four errors found
[info] compilation staged$10: completed with errors
[info] <failure>
[info] 
[info] java.lang.ClassNotFoundException: staged$10
[info] 	at scala.reflect.internal.util.AbstractFileClassLoader.findClass(AbstractFileClassLoader.scala:85)
[info] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
[info] 	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
[info] 	at lms.ScalaCompileMultiParams$class.compileAny(ScalaCompileMultiParams.scala:43)
[info] 	at microbenchmarks.S$$anon$1.compileAny(S.scala:154)
[info] 	at lms.ScalaCompileMultiParams$class.compile2(ScalaCompileMultiParams.scala:62)
[info] 	at microbenchmarks.S$$anon$1.compile2(S.scala:154)
[info] 	at microbenchmarks.S$$anon$1.<init>(S.scala:183)
[info] 	at microbenchmarks.S.prepare(S.scala:154)
[info] 	at microbenchmarks.generated.S_zip_filter_filter_staged_jmhTest._jmh_tryInit_f_s0_0(S_zip_filter_filter_staged_jmhTest.java:306)
[info] 	at microbenchmarks.generated.S_zip_filter_filter_staged_jmhTest.zip_filter_filter_staged_AverageTime(S_zip_filter_filter_staged_jmhTest.java:117)
[info] 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
[info] 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
[info] 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
[info] 	at java.lang.reflect.Method.invoke(Method.java:497)
[info] 	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:430)
[info] 	at org.openjdk.jmh.runner.BenchmarkHandler$BenchmarkTask.call(BenchmarkHandler.java:412)
[info] 	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
[info] 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
[info] 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
[info] 	at java.lang.Thread.run(Thread.java:745)
```

